### PR TITLE
Add show_flag to users

### DIFF
--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   def self.get_user_ranking
     self
       .preload(:rank)
-      .where.not(id: 1)
+      .where(show_flag: true)
       .where.not(review_count: 0)
       .order(review_count: :desc)
   end

--- a/rails/db/migrate/20210908130936_add_show_flag_to_users.rb
+++ b/rails/db/migrate/20210908130936_add_show_flag_to_users.rb
@@ -1,0 +1,5 @@
+class AddShowFlagToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :show_flag, :boolean, default: true
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_03_135201) do
+ActiveRecord::Schema.define(version: 2021_09_08_130936) do
 
   create_table "alcohols", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 2021_09_03_135201) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "rank_id", null: false
     t.integer "review_count", default: 0, null: false
+    t.boolean "show_flag", default: true
     t.index ["rank_id"], name: "index_users_on_rank_id"
   end
 


### PR DESCRIPTION
ユーザーランキングに表示しないユーザーを設定できるようにした

## やったこと
ユーザーテーブルに `show_flag` を追加
ランキング取得時に、 `show_flag = true` のユーザーに限定